### PR TITLE
corrected snapshot restore command - parameter should be --source-name

### DIFF
--- a/_posts/2018-5-7-Introducing Restore from Snapshots (Preview).html
+++ b/_posts/2018-5-7-Introducing Restore from Snapshots (Preview).html
@@ -39,7 +39,7 @@ If the extension is already installed, update it with
 <em>Restore a snapshot from the production slot to a new slot named SnapshotSlot</em>
 <pre>az webapp deployment slot create -g &lt;resource group&gt; -n &lt;name&gt; -s SnapshotSlot
 az webapp config snapshot list -g &lt;resource group&gt; -n &lt;app name&gt;
-az webapp config snapshot restore -g &lt;resource group&gt; -n &lt;name&gt; -t &lt;snapshot timestamp&gt; -s SnapshotSlot --restore-config --source-resource-group &lt;resource group&gt; --source-webapp-name &lt;name&gt;</pre>
+az webapp config snapshot restore -g &lt;resource group&gt; -n &lt;name&gt; -t &lt;snapshot timestamp&gt; -s SnapshotSlot --restore-config --source-resource-group &lt;resource group&gt; --source-name &lt;name&gt;</pre>
 <h3>Azure Powershell</h3>
 Snapshot cmdlets were added in Azure Powershell 6.0. Follow these instructions to update Azure Powershell if the snapshot cmdlets are not found.
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/Azure/AppService/blob/master/CONTRIBUTING.md
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a request to publish an article. -->
This is a fix or improvement.

## Summary

<!--
  Provide a description of what your pull request changes.
-->

The PR contains the correction for the WebApp restore command.
The parameters needs to be: --source-name instead of --source-webapp-name