### PR TITLE
Update 2020-05-15-Robust Apps for the cloud.md: Healthcheck requires …

### DIFF
--- a/_posts/2020-05-15-Robust Apps for the cloud.md
+++ b/_posts/2020-05-15-Robust Apps for the cloud.md
@@ -87,7 +87,7 @@ App Service allows you to specify a health check path on your apps. The platform
 
     ![health-check-2]({{site.baseurl}}/media/2020/04/health-check-2.png)
 
-> Please note that the Health Check feature works only when you have one or more instances, which is a **very** strong recommendation. For a single instance web app, the traffic is never blocked even if that single instance is encountering issues.
+> Please note that the Health Check feature works only when you have multiple instances, which is a **very** strong recommendation. For a single instance web app, the traffic is never blocked even if that single instance is encountering issues.
 
 **Learn More**
 

--- a/_posts/2020-05-15-Robust Apps for the cloud.md
+++ b/_posts/2020-05-15-Robust Apps for the cloud.md
@@ -87,7 +87,7 @@ App Service allows you to specify a health check path on your apps. The platform
 
     ![health-check-2]({{site.baseurl}}/media/2020/04/health-check-2.png)
 
-> Please note that the Health Check feature works only when you have multiple instances, which is a **very** strong recommendation. For a single instance web app, the traffic is never blocked even if that single instance is encountering issues.
+> Please note that the Health Check feature works only when you have two or more instances, which is a **very** strong recommendation. For a single instance web app, the traffic is never blocked even if that single instance is encountering issues.
 
 **Learn More**
 


### PR DESCRIPTION
This is a fix or improvement.

## Summary

The following two sentence seems to be contradicting each other.
"Please note that the Health Check feature works only when you have one or more instances, which is a very strong recommendation. For a single instance web app, the traffic is never blocked even if that single instance is encountering issues."

The first sentence claims Health Check feature works for single instances or multiple instances. The second sentence claims single instances don't. I'm assuming it should be as follows:
"Please note that the Health Check feature works only when you have multiple instances, which is a very strong recommendation. For a single instance web app, the traffic is never blocked even if that single instance is encountering issues."
