### PR TITLE
Updating script due to commandlet deprecation

### DIFF
--- a/_posts/2017-2-24-Creating a local PFX copy of App Service Certificate.html
+++ b/_posts/2017-2-24-Creating a local PFX copy of App Service Certificate.html
@@ -65,8 +65,8 @@ To use the script, open a PowerShell window, copy the entire script below (uncom
     Write-Host "Get Secret Access to account $loginId has been granted from the KeyVault, please check and remove the policy after exporting the certificate"
     
     ## Getting the secret from the KeyVault
-    $secret = Get-AzKeyVaultSecret -VaultName $keyVaultName -Name $keyVaultSecretName
-    $pfxCertObject= New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @([Convert]::FromBase64String($secret.SecretValueText),"",[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
+    $secret = Get-AzKeyVaultSecret -VaultName $keyVaultName -Name $keyVaultSecretName -AsPlainText
+    $pfxCertObject= New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @([Convert]::FromBase64String($secret),"",[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
     $pfxPassword = -join ((65..90) + (97..122) + (48..57) | Get-Random -Count 50 | % {[char]$_})
     $currentDirectory = (Get-Location -PSProvider FileSystem).ProviderPath
     [Environment]::CurrentDirectory = (Get-Location -PSProvider FileSystem).ProviderPath


### PR DESCRIPTION
Info from customer incident that: 

It looks like SecretValueText was deprecated from the commandlet
https://stackoverflow.com/questions/65825151/get-azkeyvaultsecret-cant-read-secret-value-in-powershell 

Updating the script to accommodate the deprecation.

<!-- Thanks for creating a Pull Request! Before you submit, please read the contributing guide at https://github.com/Azure/AppService/blob/master/CONTRIBUTING.md -->

## Summary

<!-- Provide a description of what your pull request changes. -->
