### PR TITLE
Fix parameters for secondary app deployment

### DIFF
--- a/_posts/2022-10-07-Configure automation for upgrade preferences in App Service Environment part2.md
+++ b/_posts/2022-10-07-Configure automation for upgrade preferences in App Service Environment part2.md
@@ -191,7 +191,7 @@ zip secondaryapp.zip index.php
 To deploy a sample application using *ZIP Deploy*, use this command:
 
 ```bash
-az webapp deployment source config-zip --resource-group $ASEResourceGroupNamePROD  --name $WEBAPPNamePROD --src ./secondaryapp.zip
+az webapp deployment source config-zip --resource-group $ASEResourceGroupNameDR  --name $WEBAPPNameDR --src ./secondaryapp.zip
 ```
 
 **Check if your app is running**


### PR DESCRIPTION
These parameters are for primary app, not secondary app.
```
az webapp deployment source config-zip --resource-group $ASEResourceGroupNamePROD  --name $WEBAPPNamePROD --src ./secondaryapp.zip
```

You need to deploy a zip file to the secondary app here.