### PR TITLE
Update 2021-06-22-Root-CA-on App-Service-Guide.md

### DIFF
--- a/_posts/2021-06-22-Root-CA-on App-Service-Guide.md
+++ b/_posts/2021-06-22-Root-CA-on App-Service-Guide.md
@@ -6,21 +6,22 @@ toc_sticky: true
 category: certsdomains
 ---
 
-App Service has a list of Trusted Root Certificates which you cannot modify in the multi-tenant variant version of App Service, but you can load your own CA certificate in the Trusted Root Store in an App Service Environment (ASE), which is a single-tenant environment in App Service. (The Free, Basic, Standard, and Premium App Service Plans are all multi-tenant, and the Isolated Plans are single-tenant.)
+App Service has a list of Trusted Root Certificates which you cannot modify in the multi-tenant Windows variant version of App Service, but you can load your own Certificate Authority (CA) certificate in the Trusted Root Store in an App Service Environment (ASE), which is a single-tenant environment in App Service. (The Free, Basic, Standard, and Premium App Service Plans are all multi-tenant, and the Isolated Plans are single-tenant.)
 
-When an app hosted on Azure App Service, tries to connect to a remote endpoint over SSL, it is important that the certificate on remote endpoint service is issued by a Trusted Root CA. If the certificate on the remote service is a self-signed certificate or a private CA certificate, then it will not be trusted by the instance hosting your app and the SSL handshake will fail with this error:
+When an Windows app hosted on Azure App Service tries to connect to a remote endpoint over SSL, it is important that the certificate on the remote endpoint service is issued by a Trusted Root CA. If the certificate on the remote service is a self-signed certificate or a private CA certificate, then it will not be trusted by the instance hosting your app and the SSL handshake will fail with this error:
 
 ``` 
 "Could not establish trust relationship for the SSL/TLS secure channel". 
 ```
 
-In this situtation, there are two solutions:
+In this situation, there are two solutions:
 
 1. Use a certificate that is issued by one of the Trusted Root Certificate Authorities in App Service on the remote server. 
     - [How to get a list of Trusted Root CA on App Service using Kudu](#how-to-get-a-list-of-trusted-root-ca-on-app-service-using-kudu)
 1. If the remote service endpoint certificate could not be changed or there is a need to use a private CA certificate, host your app on an App Service Environment (ASE) and load your own CA certificate in the Trusted Root Store
     - [How to load your own CA certificate to the Trusted Root Store in ASE](https://docs.microsoft.com/en-us/azure/app-service/environment/certificates#private-client-certificate)
 
+In the multi-tenant Linux and Windows Container variant version of App Service you can [load certificates](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate-in-code?tabs=linux#load-certificate-in-linuxwindows-containers) and leverage them following a typical approach depending on the image used to update the Trusted Root Store.
 
 ## How to get a list of Trusted Root CA on App Service using Kudu
 


### PR DESCRIPTION
Updated guidance clarifying differences between Windows and Containers following https://supportability.visualstudio.com/AzureAppService/_wiki/wikis/AzureAppService/830197/Using-certs-in-code-trusting-private-CAs-on-App-Service-Linux

<!-- Thanks for creating a Pull Request! Before you submit, please read the contributing guide at https://github.com/Azure/AppService/blob/master/CONTRIBUTING.md -->

## Summary

Main focus was on clarifying that the main guidance here is regarding Windows apps. For Linux/Container apps there is a workaround (based on the image - so not App Services specific guidance provided here) that we can leverage.
Made in context of https://dev.azure.com/CSSSI/CSS%20Knowledge%20Management/_workitems/edit/36352/
