### PR TITLE
Add Azure CLI App Service release posts

### DIFF
--- a/_posts/2026-01-13-azure-cli-2-82-app-service-updates.md
+++ b/_posts/2026-01-13-azure-cli-2-82-app-service-updates.md
@@ -1,0 +1,31 @@
+---
+title: "What's new for Azure App Service in Azure CLI 2.82.0"
+author_name: "Byron Tardif"
+toc: true
+toc_sticky: true
+---
+
+[Azure CLI 2.82.0](https://learn.microsoft.com/cli/azure/release-notes-azure-cli#january-13-2026) adds a preview option for discovering which Azure regions report support for Managed Instance on Azure App Service. This helps you narrow deployment planning to locations that support both Managed Instance workers and the requested pricing tier.
+
+## Find regions that support Managed Instance
+
+Use `az appservice list-locations` with `--managed-instance-enabled` and a supported Premium V4 SKU:
+
+```bash
+az appservice list-locations \
+  --managed-instance-enabled \
+  --sku P1V4
+```
+
+The command filters the location list to regions that report Managed Instance support for the selected SKU. It also supports memory-optimized Premium V4 SKUs such as `P1MV4`. Unsupported tiers return an empty list.
+
+This preview option is a discovery aid; it does not create an App Service plan or guarantee capacity in a returned region. Confirm current regional and SKU availability before deploying.
+
+## Get the release
+
+Run `az upgrade` to install the latest available Azure CLI release, then verify the installed version:
+
+```bash
+az upgrade
+az version
+```

--- a/_posts/2026-03-03-azure-cli-2-84-app-service-updates.md
+++ b/_posts/2026-03-03-azure-cli-2-84-app-service-updates.md
@@ -1,0 +1,70 @@
+---
+title: "What's new for Azure App Service in Azure CLI 2.84.0"
+author_name: "Byron Tardif"
+toc: true
+toc_sticky: true
+---
+
+[Azure CLI 2.84.0](https://learn.microsoft.com/cli/azure/release-notes-azure-cli#march-03-2026) improves VNet routing compatibility, normalizes access-restriction output, discovers Java runtimes dynamically, and adds transport-security controls during web app creation. These changes make App Service automation more predictable as Microsoft.Web APIs and supported runtimes evolve.
+
+## Keep outbound VNet routing working with newer APIs
+
+App Service now uses the site-level `outboundVnetRouting` property when web apps are created or connected to a virtual network. This replaces the older site-configuration property that is no longer honored by Microsoft.Web API version `2024-11-01`.
+
+Existing command syntax remains the same. For example, route application traffic through a regional VNet integration with:
+
+```bash
+az webapp config set \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --vnet-route-all-enabled true
+```
+
+`az webapp create` with `--vnet` and `--subnet`, and `az webapp vnet-integration add`, now update the site-level property as well. The change preserves the intended route-all behavior when these commands use the newer API.
+
+## Get consistent access-restriction output
+
+`az webapp config access-restriction show` now returns property names consistently in camel case instead of mixing camel case and snake case:
+
+```bash
+az webapp config access-restriction show \
+  --resource-group <resource-group> \
+  --name <web-app>
+```
+
+Review scripts that query specific output keys. Automation that relied on snake-case variants should move to the camel-case property names returned by this release.
+
+## Discover Java runtimes without hardcoded version lists
+
+`az webapp list-runtimes` now derives Java versions from App Service runtime metadata instead of a hardcoded list:
+
+```bash
+az webapp list-runtimes
+```
+
+This allows newly available Java versions, including Java 25 when returned by the platform, to appear without a corresponding CLI code update. The command also deduplicates repeated runtime entries.
+
+## Configure transport security when creating a web app
+
+`az webapp create` adds options for enabling encryption between the App Service front ends and workers and for setting the minimum inbound TLS version:
+
+```bash
+az webapp create \
+  --resource-group <resource-group> \
+  --plan <app-service-plan> \
+  --name <web-app> \
+  --runtime "PYTHON:3.13" \
+  --end-to-end-encryption-enabled true \
+  --min-tls-version 1.2
+```
+
+Use `--min-tls-cipher-suite` when you also need to set the minimum accepted TLS cipher suite. You can change end-to-end encryption later with `az webapp update --end-to-end-encryption-enabled`.
+
+## Get the release
+
+Run `az upgrade` to install the latest available Azure CLI release, then verify the installed version:
+
+```bash
+az upgrade
+az version
+```

--- a/_posts/2026-04-07-azure-cli-2-85-app-service-updates.md
+++ b/_posts/2026-04-07-azure-cli-2-85-app-service-updates.md
@@ -1,0 +1,87 @@
+---
+title: "What's new for Azure App Service in Azure CLI 2.85.0"
+author_name: "Byron Tardif"
+toc: true
+toc_sticky: true
+---
+
+[Azure CLI 2.85.0](https://learn.microsoft.com/cli/azure/release-notes-azure-cli#april-07-2026) adds control over Linux runtime patch adoption, default hostname generation, and automatic scaling configuration for Azure App Service. It also gives automation owners advance warning of an upcoming breaking change to `az webapp list-runtimes`.
+
+## Control when Linux runtime patches reach your app
+
+The new `--platform-release-channel` option for `az webapp update` lets you choose how quickly an App Service for Linux app adopts runtime patches:
+
+- `Latest` receives patches first and is intended for early validation.
+- `Standard` is the default and follows the normal rollout cadence.
+- `Extended` stays further behind to provide more validation time.
+
+For example, move an app to the Extended channel:
+
+```bash
+az webapp update \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --platform-release-channel Extended
+```
+
+The option also supports deployment slots. Release channels control when an app adopts platform runtime patches; they do not change the runtime family configured for the app.
+
+## Choose the scope for a generated default hostname
+
+`az webapp up` now supports `--domain-name-scope`, which controls the scope used to generate a unique default hostname during resource creation.
+
+```bash
+az webapp up \
+  --resource-group <resource-group> \
+  --plan <app-service-plan> \
+  --name <web-app> \
+  --domain-name-scope TenantReuse
+```
+
+The generated hostname can include the app name, a unique string, and the Azure region instead of relying only on `<app-name>.azurewebsites.net`. Supported scopes include tenant, subscription, resource group, and no-reuse behavior.
+
+## Use automatic scaling options without preview warnings
+
+Azure CLI no longer marks the App Service automatic scaling options as preview. Enable automatic scaling and set the plan's maximum burst capacity with:
+
+```bash
+az appservice plan update \
+  --resource-group <resource-group> \
+  --name <app-service-plan> \
+  --elastic-scale true \
+  --max-elastic-worker-count <maximum-instances>
+```
+
+You can also configure the minimum and prewarmed instance counts for a web app:
+
+```bash
+az webapp update \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --minimum-elastic-instance-count <minimum-instances> \
+  --prewarmed-instance-count <prewarmed-instances>
+```
+
+The App Service plan must support automatic scaling. The CLI accepts Premium V2 and Premium V3 plans for this configuration.
+
+## Prepare for changes to az webapp list-runtimes
+
+Azure CLI 2.85.0 begins warning about a future breaking change to `az webapp list-runtimes`. The command still returns its existing flat list in this release, but a later breaking-change release will return structured objects with these fields:
+
+- `os`
+- `runtime`
+- `version`
+- `config`
+- `support`
+- `end_of_life`
+
+The `--linux` option will be replaced by `--os-type`, and `--show-runtime-details` will be removed because the structured output includes those details. Update scripts that parse the current string list before adopting the breaking-change release.
+
+## Get the release
+
+Run `az upgrade` to install the latest available Azure CLI release, then verify the installed version:
+
+```bash
+az upgrade
+az version
+```

--- a/_posts/2026-05-05-azure-cli-2-86-app-service-updates.md
+++ b/_posts/2026-05-05-azure-cli-2-86-app-service-updates.md
@@ -1,0 +1,82 @@
+---
+title: "What's new for Azure App Service in Azure CLI 2.86.0"
+author_name: "Byron Tardif"
+toc: true
+toc_sticky: true
+---
+
+[Azure CLI 2.86.0](https://learn.microsoft.com/cli/azure/release-notes-azure-cli#may-05-2026) adds clearer App Service creation and deployment guidance, richer Linux deployment errors, Docker Compose conversion for [Site Containers](https://learn.microsoft.com/azure/app-service/migrate-sidecar-multi-container-apps), and more predictable plan creation behavior. Together, these changes reduce guesswork from plan creation through deployment and make important defaults easier to understand in automation.
+
+## Get clearer guidance when creating and deploying Linux web apps
+
+Azure CLI now provides more context around common App Service creation and deployment workflows. After creating a web app, the CLI can show relevant deployment next steps. `az webapp up` also reports inferred values such as the operating system, runtime, and generated App Service plan.
+
+When deploying a ZIP package to a Linux web app, the CLI warns when remote build is not enabled and points to the required app setting:
+
+```bash
+az webapp config appsettings set \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --settings SCM_DO_BUILD_DURING_DEPLOYMENT=true
+```
+
+The release also improves `az webapp create` validation. If you target a Linux plan without providing a runtime, container image, or Site Containers configuration, the error now lists the available creation options and directs you to runtime discovery:
+
+```bash
+az webapp list-runtimes --os-type linux
+```
+
+## Get richer Linux deployment errors
+
+`az webapp deploy` and `az webapp up` add the opt-in `--enriched-errors` parameter for Linux web apps:
+
+```bash
+az webapp deploy \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --src-path <path-to-package> \
+  --enriched-errors true
+```
+
+For recognized deployment failures, enriched output can include an error code, deployment stage, runtime and plan context, the original error, and suggested fixes. The feature recognizes a curated set of common HTTP 400 and 409 deployment failures; it does not replace startup logs or diagnose every application startup failure.
+
+This option is disabled by default.
+
+## Convert Docker Compose configuration to Site Containers
+
+If an existing web app uses the legacy `COMPOSE|` multi-container configuration, you can convert it to App Service Site Containers:
+
+```bash
+az webapp sitecontainers convert \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --mode sitecontainers \
+  --main-container-name <main-container> \
+  --yes
+```
+
+The conversion maps container images, commands, environment variables, ports, and volumes into Site Container resources. Images must already exist in their registries. Unsupported Docker Compose keys are reported and ignored, and only the first declared port becomes the target port.
+
+Review networking and storage behavior after conversion. Containers communicate through `localhost` with unique ports, `${WEBAPP_STORAGE_HOME}` maps to persistent `/home` storage, and other named volumes remain ephemeral.
+
+## Create Linux plans with a newer default SKU
+
+When `az appservice plan create` targets Linux and you omit `--sku`, Azure CLI now selects `P0V3` instead of `B1`. Windows plan creation continues to default to `B1`.
+
+```bash
+az appservice plan create \
+  --resource-group <resource-group> \
+  --name <app-service-plan> \
+  --is-linux
+```
+
+`P0V3` is a billable Premium V3 tier and is subject to regional availability. Specify `--sku` explicitly in scripts whenever the pricing tier must remain fixed.
+
+## Get the release
+
+Run `az upgrade` to install the latest available Azure CLI release, then verify the installed version:
+
+```bash
+az upgrade
+az version
+```

--- a/_posts/2026-06-02-azure-cli-2-87-app-service-updates.md
+++ b/_posts/2026-06-02-azure-cli-2-87-app-service-updates.md
@@ -1,0 +1,79 @@
+---
+title: "What's new for Azure App Service in Azure CLI 2.87.0"
+author_name: "Byron Tardif"
+toc: true
+toc_sticky: true
+---
+
+[Azure CLI 2.87.0](https://learn.microsoft.com/cli/azure/release-notes-azure-cli#june-02-2026) adds structured runtime discovery and preview commands for Linux startup logs. This release also deprecates `az webapp up` and introduces a breaking change for scripts that consume `az webapp list-runtimes` output.
+
+## Update scripts that use az webapp list-runtimes
+
+`az webapp list-runtimes` now returns structured objects instead of a flat list of strings. Each result can include its operating system, runtime family, version, configuration value, support status, and end-of-life date.
+
+The command also adds `--runtime` and `--support` filters. For example, list Python runtimes on Linux that are approaching end of life:
+
+```bash
+az webapp list-runtimes \
+  --os-type linux \
+  --runtime python \
+  --support near \
+  --output table
+```
+
+This is a breaking change for scripts that parse the previous string output. The `--linux` and `--show-runtime-details` options have been removed. Update automation to consume the new object properties and use `--os-type linux` when you need Linux results.
+
+A runtime with `Near` support status is within 365 days of its end-of-life date. The default supported view excludes end-of-life entries but can still include active, near-end-of-life, and entries without complete lifecycle metadata.
+
+## Inspect Linux startup logs from Azure CLI
+
+The new preview `az webapp log startup` commands let you list and inspect container startup attempts without opening SCM (Kudu) directly.
+
+List failed startup attempts:
+
+```bash
+az webapp log startup list \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --outcome failure
+```
+
+Show the latest relevant startup log:
+
+```bash
+az webapp log startup show \
+  --resource-group <resource-group> \
+  --name <web-app>
+```
+
+The commands support deployment slots and instance filtering. When no filename is supplied, latest-log selection prefers a failure from the newest date. Filename and instance filters cannot be used together.
+
+These commands support Linux web apps and depend on the authenticated SCM (Kudu) startup-log endpoint. A not-found response can mean the supporting capability has not reached the app's region.
+
+## Move from az webapp up to create and deploy
+
+`az webapp up` is now formally deprecated. It continues to run, but Azure CLI directs new automation toward separate creation and deployment steps.
+
+```bash
+az webapp create \
+  --resource-group <resource-group> \
+  --plan <app-service-plan> \
+  --name <web-app> \
+  --runtime "PYTHON:3.13"
+
+az webapp deploy \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --src-path <path-to-package>
+```
+
+Separating resource creation from deployment makes each operation explicit and easier to troubleshoot in scripts and CI pipelines.
+
+## Get the release
+
+Run `az upgrade` to install the latest available Azure CLI release, then verify the installed version:
+
+```bash
+az upgrade
+az version
+```

--- a/_posts/2026-08-04-azure-cli-2-89-app-service-updates.md
+++ b/_posts/2026-08-04-azure-cli-2-89-app-service-updates.md
@@ -1,0 +1,42 @@
+---
+title: "What's new for Azure App Service in Azure CLI 2.89.0"
+author_name: "Byron Tardif"
+toc: true
+toc_sticky: true
+---
+
+[Azure CLI 2.89.0](https://learn.microsoft.com/cli/azure/release-notes-azure-cli#august-04-2026) adds a new way to inspect Linux web app startup health across every running instance, making it easier to identify platform state and recent startup failures before opening individual logs.
+
+## See startup health across every Linux app instance
+
+The new `az webapp troubleshoot status` command, currently in preview, combines App Service runtime status with recent startup results from SCM (Kudu). By default, it returns structured data for every instance seen during the last 24 hours:
+
+```bash
+az webapp troubleshoot status \
+  --resource-group <resource-group> \
+  --name <web-app>
+```
+
+The result can include each instance's current state and details, its latest startup error when one is available, and counts of recent successful and failed startup attempts. This gives you an app-wide overview before you inspect an individual startup log.
+
+For a human-readable, color-coded view, add `--report`:
+
+```bash
+az webapp troubleshoot status \
+  --resource-group <resource-group> \
+  --name <web-app> \
+  --report
+```
+
+Use `--instance` with either an ARM instance ID or a machine name to inspect one worker. Add `--slot <slot-name>` to troubleshoot a deployment slot.
+
+This command supports Linux web apps. If the startup-summary endpoint is not yet available for an app, the command reports that status instead of presenting missing startup data as zero attempts. Runtime status may still be available while the supporting App Service capability rolls out across regions.
+
+## Get the release
+
+Run `az upgrade` to install the latest available Azure CLI release, then verify the installed version:
+
+```bash
+az upgrade
+az version
+```


### PR DESCRIPTION
## Summary

- Adds App Service-focused posts for Azure CLI 2.82.0, 2.84.0, 2.85.0, 2.86.0, 2.87.0, and 2.89.0
- Uses official release dates and version-specific release-note links
- Excludes Function Apps and other out-of-scope command surfaces

## Review

@seligj95 @tulikac @apwestgarth